### PR TITLE
Provide 'any' option on theme condition

### DIFF
--- a/src/Form/MenuPositionRuleForm.php
+++ b/src/Form/MenuPositionRuleForm.php
@@ -154,6 +154,10 @@ class MenuPositionRuleForm extends EntityForm {
       $form['conditions']['user_role']['negate']['#type'] = 'value';
       $form['conditions']['user_role']['negate']['#value'] = $form['conditions']['user_role']['negate']['#default_value'];
     }
+    if (isset($form['conditions']['current_theme'])) {
+      $form['conditions']['current_theme']['theme']['#empty_value'] = '';
+      $form['conditions']['current_theme']['theme']['#empty_option'] = $this->t('- Any -');
+    }
     if (isset($form['conditions']['request_path'])) {
       $form['conditions']['request_path']['#title'] = $this->t('Pages');
       $form['conditions']['request_path']['negate']['#type'] = 'radios';


### PR DESCRIPTION
I've added the `#empty_value`, which causes the display of the `- None -` option. Also, `- Any -` fits the situation better, so I've also set the `#empty_option`.

This should fix #22.
