### PR TITLE
Changed menu_position_link edit route to menu_position_rule

### DIFF
--- a/src/Plugin/Menu/MenuPositionLink.php
+++ b/src/Plugin/Menu/MenuPositionLink.php
@@ -77,5 +77,16 @@ class MenuPositionLink extends MenuLinkBase {
   public function deleteLink() {
     // noop
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditRoute() {
+    list(, $identifier) = explode(':', $this->pluginId);
+    $url = \Drupal\Core\Url::fromRoute('entity.menu_position_rule.edit_form', [
+      'menu_position_rule' => $identifier,
+    ]);
+    return $url;
+  }
 }
 


### PR DESCRIPTION
Implemented MenuPositionLink::getEditRoute() as suggested by @midnightLuke in #19.
This will lead the user to the configuration form of the corresponding menu_position_rule, with the url destination leading back to the menu form.
