### PR TITLE
flush all caches after resubmitting a form

### DIFF
--- a/src/Form/MenuPositionRuleDeleteForm.php
+++ b/src/Form/MenuPositionRuleDeleteForm.php
@@ -65,6 +65,7 @@ class MenuPositionRuleDeleteForm extends EntityConfirmFormBase {
     $this->entity->delete();
     drupal_set_message($this->t('The %label rule has been deleted.', array('%label' => $this->entity->getLabel())));
 
+    drupal_flush_all_caches();
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 }

--- a/src/Form/MenuPositionRuleForm.php
+++ b/src/Form/MenuPositionRuleForm.php
@@ -243,7 +243,9 @@ class MenuPositionRuleForm extends EntityForm {
     }
 
     // Redirect back to the menu position rule order form.
+    drupal_flush_all_caches();
     $form_state->setRedirect('entity.menu_position_rule.order_form');
+
   }
 
   /**

--- a/src/Form/MenuPositionRuleOrderForm.php
+++ b/src/Form/MenuPositionRuleOrderForm.php
@@ -31,6 +31,7 @@ class MenuPositionRuleOrderForm extends FormBase {
     $this->entity_query = $entity_query;
     $this->menu_link_manager = $menu_link_manager;
     $this->entity_manager = $entity_manager;
+    $this->db = $database;
   }
 
   public static function create(ContainerInterface $container) {
@@ -155,7 +156,7 @@ class MenuPositionRuleOrderForm extends FormBase {
       $rule->setWeight((float) $value['weight']);
       $storage->save($rule);
     }
-
     drupal_set_message($this->t('The new rules ordering has been applied.'));
+    drupal_flush_all_caches();
   }
 }

--- a/src/Form/MenuPositionSettings.php
+++ b/src/Form/MenuPositionSettings.php
@@ -9,6 +9,8 @@ namespace Drupal\menu_position\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Composer\Autoload\ClassLoader;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class MenuPositionSettings.
@@ -71,6 +73,7 @@ class MenuPositionSettings extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
+    drupal_flush_all_caches();
   }
 
 }


### PR DESCRIPTION
added drupal_flush_all_caches() to the forms for when you create/edit/delete a menu position

for issue #17 
