### PR TITLE
Declared label function for Menu Position Rule entity

### DIFF
--- a/src/Entity/MenuPositionRule.php
+++ b/src/Entity/MenuPositionRule.php
@@ -141,6 +141,13 @@ class MenuPositionRule extends ConfigEntityBase implements MenuPositionRuleInter
   /**
    * {@inheritdoc}
    */
+  public function label() {
+    return $this->label;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getEnabled() {
     return $this->enabled;
   }


### PR DESCRIPTION
Configuration Translation module calls 'label' instead of 'getLabel' to return the entity values.
Possible fix for issue #32 
