### PR TITLE
Only update certain attributes on menu_position_link

### DIFF
--- a/src/Plugin/Menu/MenuPositionLink.php
+++ b/src/Plugin/Menu/MenuPositionLink.php
@@ -10,6 +10,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInterface {
 
   /**
+   * {@inheritdoc}
+   */
+  protected $overrideAllowed = array(
+    'menu_name' => 1,
+    'parent' => 1,
+    'weight' => 1,
+  );
+
+  /**
    * The entity manager.
    *
    * @var \Drupal\Core\Entity\EntityManagerInterface
@@ -49,11 +58,6 @@ class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInt
   /**
    * {@inheritdoc}
    */
-  protected $overrideAllowed = array();
-
-  /**
-   * {@inheritdoc}
-   */
   public function getTitle() {
     // When we're in an admin route we want to display the name of the menu
     // position rule.
@@ -85,7 +89,11 @@ class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInt
    * {@inheritdoc}
    */
   public function updateLink(array $new_definition_values, $persist) {
-    return $new_definition_values;
+    // Filter the list of updates to only those that are allowed.
+    $overrides = array_intersect_key($new_definition_values, $this->overrideAllowed);
+    // Update the definition.
+    $plugin_definition = $overrides + $this->getPluginDefinition();
+    return $plugin_definition;
   }
 
   /**
@@ -115,5 +123,6 @@ class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInt
     $entity = $storage->load($entity_id);
     return $entity->urlInfo();
   }
+
 }
 


### PR DESCRIPTION
This is part of a fix for #44. The problem is that somehow the `$new_definition_values` array no longer contains a value for some essential properties, such as `route_name`. These were therefore lost during the update, resulting in the error messages of missing route `''` (`MenuLinkBase`'s default value).

I've changed the `menu_position_link`'s `updateLink` function to only update specific properties. This works similar to the implementation of [`MenuLinkContent::updateLink()`](https://api.drupal.org/api/drupal/core%21modules%21menu_link_content%21src%21Plugin%21Menu%21MenuLinkContent.php/function/MenuLinkContent%3A%3AupdateLink/8.2.x).

However, I do think that we need to change some of the handling of our menu links, as it feels very clunky to set the `menu_position_link` defaults in the `menu_position_rule` creation (see [`MenuPositionRuleForm::getPluginDefinition()`](https://github.com/LonDUG/menu_position/blob/8.x-1.x/src/Form/MenuPositionRuleForm.php#L259)), instead of handling this in the link's plugin file.
