### PR TITLE
Changed menu_position_link linking behavior

### DIFF
--- a/src/Form/MenuPositionRuleForm.php
+++ b/src/Form/MenuPositionRuleForm.php
@@ -263,9 +263,9 @@ class MenuPositionRuleForm extends EntityForm {
     $definition['menu_name'] = $menu_name;
     $definition['parent'] = $parent;
     $definition['title'] = $this->t('@label  (menu position rule)', array('@label' => $rule->getLabel()));
-    $definition['url'] = 'base:/menu-position/' . $rule->getId();
-    $definition['route_name'] = null;
-    $definition['route_parameters'] = [];
+    $definition['url'] = 'internal:<none>';
+    $definition['route_name'] = 'entity.menu_position_rule.edit_form';
+    $definition['route_parameters'] = ['menu_position_rule' => $rule->getId()];
     $definition['enabled'] = false;
     $definition['metadata'] = array('entity_id' => $rule->getId());
     $definition['provider'] = 'menu_position';

--- a/src/Form/MenuPositionRuleForm.php
+++ b/src/Form/MenuPositionRuleForm.php
@@ -263,7 +263,8 @@ class MenuPositionRuleForm extends EntityForm {
     $definition['menu_name'] = $menu_name;
     $definition['parent'] = $parent;
     $definition['title'] = $this->t('@label  (menu position rule)', array('@label' => $rule->getLabel()));
-    $definition['url'] = 'internal:<none>';
+    // Link to `<current>` route, it's the only location the link is displayed.
+    $definition['url'] = 'internal:/<current>';
     $definition['route_name'] = 'entity.menu_position_rule.edit_form';
     $definition['route_parameters'] = ['menu_position_rule' => $rule->getId()];
     $definition['enabled'] = false;

--- a/src/Plugin/Menu/MenuPositionLink.php
+++ b/src/Plugin/Menu/MenuPositionLink.php
@@ -5,6 +5,7 @@ namespace Drupal\menu_position\Plugin\Menu;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Menu\MenuLinkBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInterface {
@@ -78,7 +79,26 @@ class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInt
    * {@inheritdoc}
    */
   public function getDescription() {
-    return $this->getPluginDefinition()['description'];
+    return $this->pluginDefinition['description'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUrlObject($title_attribute = TRUE) {
+    $options = $this->getOptions();
+    if ($title_attribute && $description = $this->getDescription()) {
+      $options['attributes']['title'] = $description;
+    }
+    // If this is an admin path, return url to configuration form.
+    if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+      return new Url($this->getRouteName(), $this->getRouteParameters(), $options);
+    }
+    // Otherwise, return current page url using the default `<none>` route,
+    // as only the current page ever gets printed.
+    else {
+      return Url::fromUri($this->pluginDefinition['url']);
+    }
   }
 
   /**

--- a/src/Plugin/Menu/MenuPositionLink.php
+++ b/src/Plugin/Menu/MenuPositionLink.php
@@ -94,10 +94,9 @@ class MenuPositionLink extends MenuLinkBase implements ContainerFactoryPluginInt
     if (\Drupal::service('router.admin_context')->isAdminRoute()) {
       return new Url($this->getRouteName(), $this->getRouteParameters(), $options);
     }
-    // Otherwise, return current page url using the default `<none>` route,
-    // as only the current page ever gets printed.
+    // Otherwise, return the configured url.
     else {
-      return Url::fromUri($this->pluginDefinition['url']);
+      return Url::fromUri($this->pluginDefinition['url'], $options);
     }
   }
 


### PR DESCRIPTION
This is the second component of my fix for #44 (the other is #54). The main idea is to always provide a `route_name` (required for #44) as well as fix the `/menu-position/{menu_position_rule}` path that is not used anywhere else (this invalidates #33).

As a menu position rule does not present just one piece of content (as `menu_link_content` does), but instead applies to a wide range of (currently unknown) entities, this cannot be set properly when initiating the link. After all, we only know which content is displayed in this position when we are currently viewing said content.  
Theoretically, we don't even want to provide a link at all (but we have to*) - where should we even point it to? Therefore, I have changed the route of all `menu_position_links` to lead to their respective rule's configuration form. While this is not how "normal" menu links work, we should remember: We aren't using a "normal" menu link ;)

Additionally, we want the link to lead somewhere sensible, both when doing site-building and when displaying the `menu_position_link` within the menu (due to "When a menu position rule matches:" > "Insert the current page's title into the menu tree.").  
I have implemented the [`MenuLinkBase::getUrlObject()`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Menu%21MenuLinkBase.php/function/MenuLinkBase%3A%3AgetUrlObject/8.2.x) method to utilize a similar logic to that already used for menu link titles:
- When on an admin page, link to the corresponding rule
- Otherwise, link to the currently displayed content (which is what `<current>` does), assuming the only case when the `menu_position_link` is displayed is when we're viewing a piece of content that fulfill the link's rules conditions. The added bonus of this is, that Drupal picks up the link target and can properly add the `.is-active` CSS class :tada: (relates to #38).

This change needs to be applied to already existing `menu_position_link`s, at least if we care about backwards compatibility this early in the dev process. 
I am aware that this might cause some controversy discussions, but we really should get this module out and about, which issues such as #44 prevent. Therefore: Let's get this discussed and taken care of :)

\* We might be able to get around this once Drupal 8.2 hits, which should include `<nolink>` as a properly handled alternative.
