### PR TITLE
Allow to insert rules on a menu's top level

### DIFF
--- a/src/Form/MenuPositionRuleForm.php
+++ b/src/Form/MenuPositionRuleForm.php
@@ -179,17 +179,6 @@ class MenuPositionRuleForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    // Don't allow the user to select a menu name instead of a menu item.
-    list($menu_name, $parent) = explode(':', $form_state->getValue('parent'));
-    if (empty($parent)) {
-      $form_state->setErrorByName('parent', $this->t('Please select a menu item. You have selected the name of a menu.'));
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function save(array $form, FormStateInterface $form_state) {
     // Get menu position rule.
     $rule = $this->entity;
@@ -198,7 +187,7 @@ class MenuPositionRuleForm extends EntityForm {
     // Break apart parent selector for menu link creation.
     $link_parts = explode(':', $form_state->getValue('parent'));
     $menu_name = array_shift($link_parts);
-    $parent= implode(':', $link_parts);
+    $parent = implode(':', $link_parts);
 
     // This is a new menu position rule.
     if ($is_new) {

--- a/src/Form/MenuPositionRuleOrderForm.php
+++ b/src/Form/MenuPositionRuleOrderForm.php
@@ -84,14 +84,21 @@ class MenuPositionRuleOrderForm extends FormBase {
     // Display table of rules.
     foreach ($rules as $rule) {
       $menu_link = $rule->getMenuLinkPlugin();
-      $parent = $this->menu_link_manager->createInstance($menu_link->getParent());
+      $suffix = '';
+      if ($menu_link->getParent()) {
+        $parent = $menu_link->getParent();
+        $suffix = ' (' . $this->t('Positioned under: %title', array(
+          '%title' => $this->menu_link_manager->createInstance($parent)->getTitle(),
+        )) . ')';
+      }
       // @todo Because we're in a loop, try to cache this unless the entity
       //   manager handles all that for us. At least only get the storage once?
       $menu = $this->entity_manager->getStorage('menu')->load($menu_link->getMenuName());
       $form['rules'][$rule->getId()] = array(
         '#attributes' => array('class' => array('draggable')),
         'title' => array(
-          '#markup' => '<strong>' . $rule->getLabel() . '</strong> (' . $this->t('Positioned under: %title', array('%title' => $parent->getTitle())) . ')',
+          '#markup' => '<strong>' . $rule->getLabel() . '</strong>',
+          '#suffix' => $suffix,
         ),
         'menu_name' => array(
           '#markup' => $menu->label(),

--- a/src/Menu/MenuPositionActiveTrail.php
+++ b/src/Menu/MenuPositionActiveTrail.php
@@ -59,7 +59,13 @@ class MenuPositionActiveTrail extends MenuActiveTrail  {
             return $menu_link;
             break;
           case 'parent':
-            return $this->menuLinkManager->createInstance($menu_link->getParent());
+            if (!empty($menu_link->getParent())) {
+              return $this->menuLinkManager->createInstance($menu_link->getParent());
+            }
+            else {
+              // This is a top level menu item, there is not parent.
+              return null;
+            }
             break;
           case 'none':
             return null;


### PR DESCRIPTION
I've added some code that allows to use `menu_position_rule`s on a menu's top level. While this is probably a rare use case, it feels like a arbitrary limitation of the module's functionality.

Additionally, nothing prevents the user from moving a rule to the top level using drag-and-drop (as long as this does not crash the site). So we'd either need to add safety measures to prevent such movement, or simply allow top level positioning ;) The changes are rather straight forward.
